### PR TITLE
Persist timestamps as int64s

### DIFF
--- a/message.go
+++ b/message.go
@@ -34,10 +34,10 @@ const (
 
 // Message is, simply, the message to be passed between recipients
 type Message struct {
-	Source    Source    `mapstructure:"source"`
-	ID        string    `mapstructure:"id"`
-	Timestamp time.Time `mapstructure:"ts"`
-	Message   string    `mapstructure:"msg"`
+	Source    Source `mapstructure:"source"`
+	ID        string `mapstructure:"id"`
+	Timestamp int64  `mapstructure:"ts"`
+	Message   string `mapstructure:"msg"`
 }
 
 // NewMessage accepts a source, id and string, and returns a new Message
@@ -45,7 +45,7 @@ func NewMessage(source Source, id, msg string) Message {
 	return Message{
 		Source:    source,
 		ID:        id,
-		Timestamp: time.Now(),
+		Timestamp: time.Now().Unix(),
 		Message:   msg,
 	}
 }
@@ -63,4 +63,8 @@ func (m Message) Map() (o map[string]any) {
 	_ = mapstructure.Decode(m, &o)
 
 	return
+}
+
+func (m Message) GetTimestamp() time.Time {
+	return time.Unix(m.Timestamp, 0)
 }

--- a/message_test.go
+++ b/message_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -40,9 +39,9 @@ func TestParseMessage(t *testing.T) {
 		{"Happy path", map[string]interface{}{"source": 2, "ts": 0, "id": "some-id", "msg": "<3"}, Message{
 			Source:    SourceAutoresponse,
 			ID:        "some-id",
-			Timestamp: time.Time{},
+			Timestamp: 0,
 			Message:   "<3",
-		}, true},
+		}, false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			m, err := ParseMessage(test.m)
@@ -65,13 +64,13 @@ func TestMessage_Map(t *testing.T) {
 		m      Message
 		expect map[string]any
 	}{
-		{"Empty message", Message{}, map[string]any{"id": "", "msg": "", "source": Source(0), "ts": map[string]any{}}},
+		{"Empty message", Message{}, map[string]any{"id": "", "msg": "", "source": Source(0), "ts": int64(0)}},
 		{"Happy path", Message{
 			Source:    SourceAutoresponse,
 			ID:        "some-id",
-			Timestamp: time.Time{},
+			Timestamp: 0,
 			Message:   "<3",
-		}, map[string]any{"source": Source(2), "ts": map[string]any{}, "id": "some-id", "msg": "<3"}},
+		}, map[string]any{"source": Source(2), "ts": int64(0), "id": "some-id", "msg": "<3"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			m := test.m.Map()
@@ -80,5 +79,14 @@ func TestMessage_Map(t *testing.T) {
 				t.Error(cmp.Diff(test.expect, m))
 			}
 		})
+	}
+}
+
+func TestMessage_GetTimestamp(t *testing.T) {
+	expect := "2022-10-02 18:31:15 +0000 UTC"
+	got := Message{Timestamp: 1664735475}.GetTimestamp().UTC().String()
+
+	if expect != got {
+		t.Errorf("expected %q, received %q", expect, got)
 	}
 }


### PR DESCRIPTION
Because mapstructure doesn't do anything fancy with how it serialises time.Time types (see:
https://github.com/mitchellh/mapstructure/issues/270, and https://github.com/mitchellh/mapstructure/issues/159) we have a couple of options; either do some fancy HookFunction stuff, or just sack it off and not add extra reflection nonsense.

Our current strategy uses int64s anyway, so this also allows us some degree of backwards compatibility and so we wont need to do a massive big-bang rollout.

---

This PR also fixes a bug in tests, where a valid case was marked as expecting an error. Oops.