### PR TITLE
Binary ummarshaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 ---
 # types
 
+types holds common data structures used across GEC components.
+
 ## Types
 
 ### type [Message](https://github.com/gender-equality-community/types/blob/main/message.go#L36)
@@ -18,6 +20,10 @@
 `type Message struct { ... }`
 
 Message is, simply, the message to be passed between recipients
+
+#### func (Message) [GetTimestamp](https://github.com/gender-equality-community/types/blob/main/message.go#L68)
+
+`func (m Message) GetTimestamp() time.Time`
 
 #### func (Message) [Map](https://github.com/gender-equality-community/types/blob/main/message.go#L62)
 

--- a/message.go
+++ b/message.go
@@ -65,6 +65,11 @@ func (m Message) Map() (o map[string]any) {
 	return
 }
 
+// GetTimestamp takes the unixtimestamp stored within a Message and returns
+// a localised time.Time based on this.
+//
+// Note: to get the time in UTC you'll need to do
+//    m.GetTimestamp().UTC()
 func (m Message) GetTimestamp() time.Time {
 	return time.Unix(m.Timestamp, 0)
 }

--- a/message.go
+++ b/message.go
@@ -6,11 +6,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-// Source signifies the source of a message; whether it's come
-// in from whatsapp, slack, some kind of auto-responder, or just
-// completely unknown
-type Source uint8
-
 const (
 	// SourceUnknown is where we simply ust don't know where a message comes from,
 	// and is largely only used for zero'd messages, or when errors stop the
@@ -31,6 +26,31 @@ const (
 	// dunno
 	SourceSlack
 )
+
+// Source signifies the source of a message; whether it's come
+// in from whatsapp, slack, some kind of auto-responder, or just
+// completely unknown
+type Source uint8
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface
+// in order to serialise data to redis correctly
+func (s Source) MarshalBinary() ([]byte, error) {
+	return []byte{uint8(s)}, nil
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+// in order to serialise data _from_ redis correctly
+func (s *Source) UnmarshalBinary(data []byte) error {
+	if len(data) != 1 {
+		*s = SourceUnknown
+
+		return nil
+	}
+
+	*s = Source(data[0])
+
+	return nil
+}
 
 // Message is, simply, the message to be passed between recipients
 type Message struct {

--- a/message_test.go
+++ b/message_test.go
@@ -6,6 +6,47 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestSource_MarshalBinary(t *testing.T) {
+	var empty Source
+
+	for _, test := range []struct {
+		name   string
+		s      Source
+		expect []byte
+	}{
+		{"Empty Source marshals to 0x0", empty, []byte{0x0}},
+		{"Autoresponse marshals to 0x2", SourceAutoresponse, []byte{0x2}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			received, _ := test.s.MarshalBinary()
+			if !cmp.Equal(test.expect, received) {
+				t.Error(cmp.Diff(test.expect, received))
+			}
+		})
+	}
+}
+
+func TestSource_UnmarshalBinary(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		s      []byte
+		expect Source
+	}{
+		{"Empty Source unmarshals from 0x0", []byte{}, SourceUnknown},
+		{"Garbage/ broken data unmarshals to Unknown", []byte("hello, world!"), SourceUnknown},
+		{"Autoresponse unmarshals from 0x2", []byte{0x2}, SourceAutoresponse},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var received Source
+
+			_ = received.UnmarshalBinary(test.s)
+			if !cmp.Equal(test.expect, received) {
+				t.Error(cmp.Diff(test.expect, received))
+			}
+		})
+	}
+}
+
 func TestNewMessage(t *testing.T) {
 	m := NewMessage(SourceAutoresponse, "some-id", "Hello, world!")
 


### PR DESCRIPTION
In order to serialise a `Source` properly to and from redis, we must implement these interfaces. 

We could, instead, keep sources as naked `uint8`s and, instead, manually assign numeric values but that's messier and takes away the power later to be able to put other operations on `Source`s, like strings or workflow rules.